### PR TITLE
Update sha-bang for better compatibility

### DIFF
--- a/runner
+++ b/runner
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import sys
 import distutils.dir_util
 import blog


### PR DESCRIPTION
`#!/usr/bin/x` doesn't always work, because the application might be installed somewhere else, for example, on Mac, `brew` installs packages in `/usr/local/Cellar`.

Using `usr/bin/env x` always works.
